### PR TITLE
Morphtargets Webcam Example: Apply eye rotation

### DIFF
--- a/examples/webgl_morphtargets_webcam.html
+++ b/examples/webgl_morphtargets_webcam.html
@@ -126,6 +126,9 @@
 
 			// Face
 
+			let face, eyeL, eyeR;
+			const eyeRotationLimit = THREE.MathUtils.degToRad( 30 );
+
 			const ktx2Loader = new KTX2Loader()
 				.setTranscoderPath( 'jsm/libs/basis/' )
 				.detectSupport( renderer );
@@ -140,6 +143,10 @@
 
 					const head = mesh.getObjectByName( 'mesh_2' );
 					head.material = new THREE.MeshNormalMaterial();
+
+					face = mesh.getObjectByName( 'mesh_2' );
+					eyeL = mesh.getObjectByName( 'eyeLeft' );
+  					eyeR = mesh.getObjectByName( 'eyeRight' );
 
 					// GUI
 
@@ -208,6 +215,13 @@
 
 			const transform = new THREE.Object3D();
 
+			// convert -1 to 1 value into eye rotation value
+			function mapRotation( eyeScore ) {
+
+				return THREE.MathUtils.mapLinear( eyeScore, - 1, 1, - eyeRotationLimit, eyeRotationLimit );
+
+			}
+
 			function animation() {
 
 				if ( video.readyState >= HTMLMediaElement.HAVE_METADATA ) {
@@ -233,18 +247,24 @@
 
 					}
 
-					if ( results.faceBlendshapes.length > 0  ) {
-
-						const face = scene.getObjectByName( 'mesh_2' );
-
+					if ( results.faceBlendshapes.length > 0 ) {
+			
 						const faceBlendshapes = results.faceBlendshapes[ 0 ].categories;
+			
+						// Morph values does not exist on the eye meshes, so we map the eyes blendshape score into rotation values
+						const eyeScore = {
+							leftHorizontal: 0,
+							rightHorizontal: 0,
+							leftVertical: 0,
+							rightVertical: 0,
+      						};
 
 						for ( const blendshape of faceBlendshapes ) {
 
 							const categoryName = blendshape.categoryName;
 							const score = blendshape.score;
 
-							const index = face.morphTargetDictionary[ blendshapesMap[  categoryName ] ];
+							const index = face.morphTargetDictionary[ blendshapesMap[ categoryName ] ];
 
 							if ( index !== undefined ) {
 
@@ -252,8 +272,44 @@
 
 							}
 
+							// There are two blendshape for movement on each axis (up/down , in/out)
+							// Add one and subtract the other to get the final rotation in -1 to 1 range
+							switch ( categoryName ) {
+
+								case 'eyeLookInLeft':
+									eyeScore.leftHorizontal += score;
+									break;
+								case 'eyeLookOutLeft':
+									eyeScore.leftHorizontal -= score;
+									break;
+								case 'eyeLookInRight':
+									eyeScore.rightHorizontal -= score;
+									break;
+								case 'eyeLookOutRight':
+									eyeScore.rightHorizontal += score;
+									break;
+								case 'eyeLookUpLeft':
+									eyeScore.leftVertical -= score;
+									break;
+								case 'eyeLookDownLeft':
+									eyeScore.leftVertical += score;
+									break;
+								case 'eyeLookUpRight':
+									eyeScore.rightVertical -= score;
+									break;
+								case 'eyeLookDownRight':
+									eyeScore.rightVertical += score;
+									break;
+
+							}
+
 						}
 
+					eyeL.rotation.z = mapRotation( eyeScore.leftHorizontal );
+      					eyeR.rotation.z = mapRotation( eyeScore.rightHorizontal );
+      					eyeL.rotation.x = mapRotation( eyeScore.leftVertical );
+      					eyeR.rotation.x = mapRotation( eyeScore.rightVertical );
+			
 					}
 
 				}


### PR DESCRIPTION

**Description**

Using the eye rotation morph/blend scores to drive the eyeball mesh rotation


Before | After

https://github.com/vis-prime/three.js/assets/119810373/c05d8fb7-6fca-4487-845b-8221563b4b16

